### PR TITLE
Extracting table names from nodes

### DIFF
--- a/psqlparse/nodes/__init__.py
+++ b/psqlparse/nodes/__init__.py
@@ -1,5 +1,5 @@
 from .parsenodes import (SelectStmt, InsertStmt, UpdateStmt, DeleteStmt,
                          WithClause, CommonTableExpr, RangeSubselect,
                          ResTarget, ColumnRef, AStar, AExpr, AConst)
-from .primnodes import RangeVar, JoinExpr, Alias, IntoClause, BoolExpr
+from .primnodes import RangeVar, JoinExpr, Alias, IntoClause, BoolExpr, SubLink
 from .value import Integer, String, Float

--- a/psqlparse/nodes/nodes.py
+++ b/psqlparse/nodes/nodes.py
@@ -1,2 +1,22 @@
+import six
+
+
 class Node(object):
-    pass
+
+    def tables(self):
+        """
+        Generic method that does a depth-first search on the node attributes.
+
+        Child classes should override this method for better performance.
+        """
+        _tables = set()
+
+        for attr in six.itervalues(self.__dict__):
+            if isinstance(attr, list):
+                for item in attr:
+                    if isinstance(item, Node):
+                        _tables |= item.tables()
+            elif isinstance(attr, Node):
+                _tables |= attr.tables()
+
+        return _tables

--- a/psqlparse/nodes/parsenodes.py
+++ b/psqlparse/nodes/parsenodes.py
@@ -85,6 +85,19 @@ class UpdateStmt(Statement):
         self.returning_list = build_from_item(obj, 'returningList')
         self.with_clause = build_from_item(obj, 'withClause')
 
+    def tables(self):
+        _tables = self.relation.tables()
+
+        if self.where_clause:
+            _tables |= self.where_clause.tables()
+        if self.from_clause:
+            for item in self.from_clause:
+                _tables |= item.tables()
+        if self.with_clause:
+            _tables |= self.with_clause.tables()
+
+        return _tables
+
 
 class DeleteStmt(Statement):
 
@@ -96,6 +109,19 @@ class DeleteStmt(Statement):
         self.where_clause = build_from_item(obj, 'whereClause')
         self.returning_list = build_from_item(obj, 'returningList')
         self.with_clause = build_from_item(obj, 'withClause')
+
+    def tables(self):
+        _tables = self.relation.tables()
+
+        if self.using_clause:
+            for item in self.using_clause:
+                _tables |= item.tables()
+        if self.where_clause:
+            _tables |= self.where_clause.tables()
+        if self.with_clause:
+            _tables |= self.with_clause.tables()
+
+        return _tables
 
 
 class WithClause(Node):
@@ -149,6 +175,9 @@ class RangeSubselect(Node):
         self.subquery = build_from_item(obj, 'subquery')
         self.alias = build_from_item(obj, 'alias')
 
+    def tables(self):
+        return self.subquery.tables()
+
 
 class ResTarget(Node):
     """
@@ -173,6 +202,9 @@ class ResTarget(Node):
         self.val = build_from_item(obj, 'val')
         self.location = obj.get('location')
 
+    def tables(self):
+        return set()
+
 
 class ColumnRef(Node):
 
@@ -180,11 +212,17 @@ class ColumnRef(Node):
         self.fields = build_from_item(obj, 'fields')
         self.location = obj.get('location')
 
+    def tables(self):
+        return set()
+
 
 class AStar(Node):
 
     def __init__(self, obj):
         pass
+
+    def tables(self):
+        return set()
 
 
 class AExpr(Node):
@@ -196,9 +234,15 @@ class AExpr(Node):
         self.rexpr = build_from_item(obj, 'rexpr')
         self.location = obj.get('location')
 
+    def tables(self):
+        return self.lexpr.tables() | self.rexpr.tables()
+
 
 class AConst(Node):
 
     def __init__(self, obj):
         self.val = build_from_item(obj, 'val')
         self.location = obj.get('location')
+
+    def tables(self):
+        return set()

--- a/psqlparse/nodes/primnodes.py
+++ b/psqlparse/nodes/primnodes.py
@@ -21,6 +21,9 @@ class RangeVar(Node):
         self.alias = obj.get('alias')
         self.location = obj['location']
 
+    def tables(self):
+        return {self.relname}
+
     def __repr__(self):
         return '<RangeVar (%s)>' % self.relname
 
@@ -62,10 +65,26 @@ class IntoClause(Node):
         self._obj = obj
 
 
-class BoolExpr(Node):
+class Expr(Node):
+    """
+    Expr - generic superclass for executable-expression nodes
+    """
+
+
+class BoolExpr(Expr):
 
     def __init__(self, obj):
-        self.xpr = obj.get('xpr')
         self.boolop = obj.get('boolop')
         self.args = build_from_item(obj, 'args')
+        self.location = obj.get('location')
+
+
+class SubLink(Expr):
+
+    def __init__(self, obj):
+        self.sub_link_type = obj.get('subLinkType')
+        self.sub_link_id = obj.get('subLinkId')
+        self.testexpr = build_from_item(obj, 'testexpr')
+        self.oper_name = build_from_item(obj, 'operName')
+        self.subselect = build_from_item(obj, 'subselect')
         self.location = obj.get('location')

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -242,3 +242,10 @@ class TablesTest(unittest.TestCase):
                  "INSERT INTO dataset SELECT * FROM fake")
         stmt = parse(query).pop()
         self.assertEqual(stmt.tables(), {'inner_table', 'fake', 'dataset'})
+
+    def test_delete(self):
+        query = ("DELETE FROM dataset USING table_one "
+                 "WHERE x = y OR x IN (SELECT * from table_two)")
+        stmt = parse(query).pop()
+        self.assertEqual(stmt.tables(), {'dataset', 'table_one',
+                                         'table_two'})

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -225,6 +225,11 @@ class TablesTest(unittest.TestCase):
         self.assertEqual(stmt.tables(),
                          {'table_one', 'table_two', 'dataset'})
 
+    def test_update_from(self):
+        query = "UPDATE dataset SET a = 5 FROM extra WHERE b = c"
+        stmt = parse(query).pop()
+        self.assertEqual(stmt.tables(), {'dataset', 'extra'})
+
     def test_join(self):
         query = ("SELECT * FROM table_one JOIN table_two USING (common_1)"
                  " JOIN table_three USING (common_2)")

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -121,6 +121,14 @@ class SelectQueriesTest(unittest.TestCase):
         self.assertEqual([1, 'one'], [v.val.val
                                       for v in subquery.values_lists[0]])
 
+    def test_select_case(self):
+        query = ("SELECT a, CASE WHEN a=1 THEN 'one' WHEN a=2 THEN 'two'"
+                 " ELSE 'other' END FROM test")
+        stmt = parse(query).pop()
+        self.assertIsInstance(stmt, nodes.SelectStmt)
+
+        self.assertEqual(len(stmt.target_list), 2)
+
 
 class InsertQueriesTest(unittest.TestCase):
 
@@ -202,6 +210,16 @@ class WrongQueriesTest(unittest.TestCase):
         except PSqlParseError as e:
             self.assertEqual(e.cursorpos, 21)
             self.assertEqual(e.message, 'syntax error at end of input')
+
+    def test_case_no_value(self):
+        query = ("SELECT a, CASE WHEN a=1 THEN 'one' WHEN a=2 THEN "
+                 " ELSE 'other' END FROM test")
+        try:
+            parse(query)
+            self.fail('Syntax error not generating an PSqlParseError')
+        except PSqlParseError as e:
+            self.assertEqual(e.cursorpos, 51)
+            self.assertEqual(e.message, 'syntax error at or near "ELSE"')
 
 
 class TablesTest(unittest.TestCase):


### PR DESCRIPTION
Every node has a `tables` method to extract its references to a table.

A generic method (algorithm) was implemented to account for any new Node that doesn't implement `tables` method.