### PR TITLE
Include schema names in returned table names where given

### DIFF
--- a/psqlparse/nodes/primnodes.py
+++ b/psqlparse/nodes/primnodes.py
@@ -28,7 +28,11 @@ class RangeVar(Node):
         return '%s' % self.relname
 
     def tables(self):
-        return {self.relname}
+        components = [
+            getattr(self, name) for name in ('schemaname', 'relname')
+            if getattr(self, name, None) is not None
+        ]
+        return {'.'.join(components)}
 
 
 class JoinExpr(Node):

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -248,6 +248,11 @@ class TablesTest(unittest.TestCase):
         stmt = parse(query).pop()
         self.assertEqual(stmt.tables(), {'table_one', 'table_two'})
 
+    def test_simple_select_using_schema_names(self):
+        query = "SELECT * FROM table_one, public.table_one"
+        stmt = parse(query).pop()
+        self.assertEqual(stmt.tables(), {'table_one', 'public.table_one'})
+
     def test_select_with(self):
         query = ("WITH fake_table AS (SELECT * FROM inner_table) "
                  "SELECT * FROM fake_table")


### PR DESCRIPTION
The table names returned by `Node.tables()` are all unqualified, even when the schema name is given in the SQL statement. Before this PR:

```
In [2]: psqlparse.parse('select * from schema_a.my_table, schema_b.my_table')[0].tables()
Out[2]: {'my_table'}
```

This means results are both ambiguous (which `my_table` is/are being used?) and potentially misleading (since `len(....tables())` suggests that only one table is used in the statement).

This PR avoids these problems whenever possible. After this PR:

```
In [2]: psqlparse.parse('select * from schema_a.my_table, schema_b.my_table')[0].tables()
Out[2]: {'schema_a.my_table', 'schema_b.my_table'}
```

We will continue to have ambiguous and potentially misleading results when some table names are qualified and others are unqualified:

```
In [3]: psqlparse.parse('select * from my_table, schema_b.my_table')[0].tables()
Out[3]: {'my_table', 'schema_b.my_table'}
```

This is strictly an improvement, however, because `Node.tables()` no longer destroys information that does exist about the tables referenced in the query. Application logic can still use these results to resolve references if needed.