### PR TITLE
Add NullTest node object

### DIFF
--- a/psqlparse/nodes/__init__.py
+++ b/psqlparse/nodes/__init__.py
@@ -1,5 +1,5 @@
 from .parsenodes import (SelectStmt, InsertStmt, UpdateStmt, DeleteStmt,
                          WithClause, CommonTableExpr, RangeSubselect,
                          ResTarget, ColumnRef, FuncCall, AStar, AExpr, AConst)
-from .primnodes import RangeVar, JoinExpr, Alias, IntoClause, BoolExpr, SubLink
+from .primnodes import RangeVar, JoinExpr, Alias, IntoClause, BoolExpr, SubLink, NullTest
 from .value import Integer, String, Float

--- a/psqlparse/nodes/primnodes.py
+++ b/psqlparse/nodes/primnodes.py
@@ -113,5 +113,4 @@ class NullTest(Node):
         self.location = obj.get('location')
 
     def tables(self):
-        _tables = self.arg.tables()
-        return _tables
+        return set()

--- a/psqlparse/nodes/primnodes.py
+++ b/psqlparse/nodes/primnodes.py
@@ -103,3 +103,15 @@ class SubLink(Expr):
 
     def tables(self):
         return self.subselect.tables()
+
+
+class NullTest(Node):
+
+    def __init__(self, obj):
+        self.arg = build_from_item(obj, 'arg')
+        self.nulltesttype = obj.get('nulltesttype')
+        self.location = obj.get('location')
+
+    def tables(self):
+        _tables = self.arg.tables()
+        return _tables

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -148,6 +148,15 @@ class SelectQueriesTest(unittest.TestCase):
         self.assertEqual(str(func_call.args[0].fields[0]), 'geo1')
         self.assertEqual(str(func_call.args[1].fields[0]), 'geo2')
 
+    def test_select_with_null_test(self):
+        query = "SELECT * FROM my_table WHERE a is NULL"
+        stmt = parse(query).pop()
+        self.assertIsInstance(stmt.where_clause, nodes.NullTest)
+
+        query = "SELECT * FROM my_table WHERE a is not NULL"
+        stmt = parse(query).pop()
+        self.assertIsInstance(stmt.where_clause, nodes.NullTest)
+
 
 class InsertQueriesTest(unittest.TestCase):
 


### PR DESCRIPTION
Re: #6 

This just adds a `NullTest` object to make tree traversal more consistent for this node type (i.e. this node no longer appears as a `{'NullTest': ...}` dictionary).