### PR TITLE
Add `RowExpr` class

### DIFF
--- a/psqlparse/nodes/__init__.py
+++ b/psqlparse/nodes/__init__.py
@@ -4,5 +4,6 @@ from .parsenodes import (SelectStmt, InsertStmt, UpdateStmt, DeleteStmt,
                          TypeCast, TypeName, SortBy, WindowDef, LockingClause,
                          RangeFunction, AArrayExpr, AIndices, MultiAssignRef)
 from .primnodes import (RangeVar, JoinExpr, Alias, IntoClause, BoolExpr,
-                        SubLink, SetToDefault, CaseExpr, CaseWhen, NullTest)
+                        SubLink, SetToDefault, CaseExpr, CaseWhen, NullTest,
+                        RowExpr)
 from .value import Integer, String, Float

--- a/psqlparse/nodes/primnodes.py
+++ b/psqlparse/nodes/primnodes.py
@@ -144,3 +144,13 @@ class NullTest(Node):
         self.nulltesttype = obj.get('nulltesttype')
         self.argisrow = obj.get('argisrow')
         self.location = obj.get('location')
+
+
+class RowExpr(Node):
+
+    def __init__(self, obj):
+        self.args = build_from_item(obj, 'args')
+        self.colnames = build_from_item(obj, 'colnames')
+        self.location = obj['location']
+        self.row_format = obj.get('row_format')
+        self.type_id = obj.get('typeId')

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -296,6 +296,14 @@ class SelectQueriesTest(unittest.TestCase):
         self.assertIsInstance(inner.args[0], nodes.AArrayExpr)
         self.assertEqual(len(inner.args[0].elements), 6)
 
+    def test_select_where_in_many(self):
+        query = (
+            "SELECT * FROM my_table WHERE (a, b) in (('a', 'b'), ('c', 'd'))")
+        stmt = parse(query).pop()
+        self.assertEqual(2, len(stmt.where_clause.rexpr))
+        for node in stmt.where_clause.rexpr:
+            self.assertIsInstance(node, nodes.RowExpr)
+
 
 class InsertQueriesTest(unittest.TestCase):
 
@@ -502,6 +510,13 @@ class TablesTest(unittest.TestCase):
 
     def test_where_in_expr(self):
         query = "SELECT * FROM my_table WHERE (a, b) in ('a', 'b')"
+        stmt = parse(query).pop()
+        self.assertIsInstance(stmt, nodes.SelectStmt)
+        self.assertEqual(stmt.tables(), {'my_table'})
+
+    def test_where_in_expr_many(self):
+        query = (
+            "SELECT * FROM my_table WHERE (a, b) in (('a', 'b'), ('c', 'd'))")
         stmt = parse(query).pop()
         self.assertIsInstance(stmt, nodes.SelectStmt)
         self.assertEqual(stmt.tables(), {'my_table'})


### PR DESCRIPTION
Added `RowExpr` class and simple tests. It's my first time looking at postresql parse trees so happy to rework this given feedback.

This closes #33 